### PR TITLE
Compile with older version of Java

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-11.0.25.9.1
+java corretto-8.432.06.1

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   "com.novocode" % "junit-interface" % "0.11" % Test
 )
 
-Compile / compile / javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
+Compile / compile / javacOptions ++= Seq("-source", "1.5", "-target", "1.5")
 
 organization := "com.madgag"
 licenses := Seq(License.Apache2)


### PR DESCRIPTION
The point of `use-newer-java` is that it will run- and print a friendly message - even if the user is using a really old version of Java - so `use-newer-java` needs to be compiled to target that old version - as old as we can get away with.

By compiling using old, old, Java 8, we can target Java 1.5 (aka Java 5), and ensure that `use-newer-java` manages to print that friendly message even on an improbably old version of Java.

https://en.wikipedia.org/wiki/Java_version_history
